### PR TITLE
🐛  default to `config.json` if NODE_ENV is not set

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -3,12 +3,18 @@ var nconf = require('nconf'),
 
 var defaults = require(path.join(process.cwd(), 'config.example'));
 
+function getConfigFileName() {
+    return (process.env.NODE_ENV) ?
+        'config.' + process.env.NODE_ENV + '.json' :
+        'config.json';
+}
+
 nconf.set('NODE_ENV', process.env.NODE_ENV);
 
 nconf.argv()
     .env()
     .file({
-        file: path.join(process.cwd(), 'config.' + process.env.NODE_ENV + '.json')
+        file: path.join(process.cwd(), getConfigFileName())
     });
 
 nconf.defaults(defaults);


### PR DESCRIPTION
There might be a better way to go about this; however, using `npm start` without any additional arguments doesn't actually add a `NODE_ENV` environment variable, so for any consuming applications, this might fix any surprising behavior when NODE_ENV is not set.
