### PR TITLE
🐛  change how we load config.example

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,15 +1,36 @@
 var nconf = require('nconf'),
-    path = require('path');
+    fs = require('fs'),
+    path = require('path'),
+    findRoot = require('find-root'),
+    defaults = {},
+    getParentPath = function (parent) {
+        if (!parent  || !parent.filename) {
+            return null;
+        }
 
-var defaults = require(path.join(process.cwd(), 'config.example'));
+        if (parent.filename.match(/ghost-ignition/gi)) {
+            return getParentPath(parent.parent);
+        }
+
+        // finds the root with package.json based on a path
+        return findRoot(parent.filename);
+    },
+    parentPath = getParentPath(module.parent);
+
+if (parentPath && fs.existsSync(path.join(parentPath, 'config.example.json'))) {
+    defaults = require(path.join(parentPath, 'config.example.json'));
+}
 
 nconf.set('NODE_ENV', process.env.NODE_ENV);
 
 nconf.argv()
     .env()
     .file({
-        file: path.join(process.cwd(), 'config.' + process.env.NODE_ENV + '.json')
+        file: path.join(parentPath, 'config.' + process.env.NODE_ENV + '.json')
     });
 
 nconf.defaults(defaults);
+
+// @TODO: this file gets cached after the first require, we need to redesign how we load the config
+// @TODO: for example: require('ghost-ignition').config()
 module.exports = nconf;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "debug": "2.2.0",
     "express": "4.14.0",
+    "find-root": "1.0.0",
     "nconf": "0.8.4",
     "randomstring": "1.1.5"
   },


### PR DESCRIPTION
refs #3

There are three problems:
1. config.example.json was loaded via `process.cwd`, which can be wrong, because its the current working directory. the path must be the path to the parent who required the module (solved in this PR)
2. it required a config.example.json, which needs to be optional (solved in this PR)
3. config is a cached file, we need a dynamic function here because if multiple modules using ghost-ignition, we need to load the config files again (not solved in this PR, see TODO in PR)
