### PR TITLE
Default environment for null process.env.NODE_ENV

### DIFF
--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -1,0 +1,1 @@
+module.exports = process.env.NODE_ENV || 'development';

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,9 +1,9 @@
-var nconf = require('nconf'),
-    fs = require('fs'),
-    path = require('path'),
-    findRoot = require('find-root'),
-    defaults = {},
-    getParentPath = function (parent) {
+var nconf = require('nconf');
+var fs = require('fs');
+var path = require('path');
+var findRoot = require('find-root');
+var defaults = {};
+var getParentPath = function (parent) {
         if (!parent  || !parent.filename) {
             return null;
         }
@@ -14,19 +14,20 @@ var nconf = require('nconf'),
 
         // finds the root with package.json based on a path
         return findRoot(parent.filename);
-    },
-    parentPath = getParentPath(module.parent);
+    };
+var parentPath = getParentPath(module.parent);
+var env = require('./env');
 
 if (parentPath && fs.existsSync(path.join(parentPath, 'config.example.json'))) {
     defaults = require(path.join(parentPath, 'config.example.json'));
 }
 
-nconf.set('NODE_ENV', process.env.NODE_ENV);
+nconf.set('NODE_ENV', env);
 
 nconf.argv()
     .env()
     .file({
-        file: path.join(parentPath, 'config.' + process.env.NODE_ENV + '.json')
+        file: path.join(parentPath, 'config.' + env + '.json')
     });
 
 nconf.defaults(defaults);


### PR DESCRIPTION
This sets a fallback development environment to use with nconf in the case where process.env.NODE_ENV has not been set. 

No Issue
- sets NODE_ENV to development if process.env.NODE_ENV is null
