### PR TITLE
🐛  downgrade bunyan to 1.8.1

### DIFF
--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -3,6 +3,7 @@ var bunyan = require('bunyan'),
     GhostPrettyStream = require('./PrettyStream');
 
 function GhostLogger(options) {
+    options = options || {};
     var self = this;
 
     this.env = options.env || 'development';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/TryGhost/Ignition#readme",
   "dependencies": {
-    "bunyan": "1.8.3",
+    "bunyan": "1.8.1",
     "debug": "2.2.0",
     "express": "4.14.0",
     "find-root": "1.0.0",
@@ -32,9 +32,11 @@
     "randomstring": "1.1.5"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "3.5.0",
     "grunt": "1.0.1",
     "grunt-release": "0.14.0",
-    "mocha": "^3.0.1"
+    "mocha": "3.0.1",
+    "should": "11.1.1",
+    "sinon": "1.17.6"
   }
 }

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,0 +1,27 @@
+var PrettyStream = require('../lib/logging/PrettyStream');
+var GhostLogger = require('../lib/logging/GhostLogger');
+var sinon = require('sinon');
+var should = require('should');
+var sandbox = sinon.sandbox.create();
+
+describe('Logging', function () {
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    // in Bunyan 1.8.3 they have changed this behaviour
+    // they are trying to find the err.message attribute and forward this as msg property
+    // our PrettyStream implementation can't handle this case
+    it('ensure stdout write properties', function (done) {
+        sandbox.stub(PrettyStream.prototype, 'write', function (data) {
+            should.exist(data.req);
+            should.exist(data.res);
+            should.exist(data.err);
+            data.msg.should.eql('');
+            done();
+        });
+
+        var ghostLogger = new GhostLogger();
+        ghostLogger.info({err: new Error('message'), req: {body: {}}, res: {headers: {}}});
+    });
+});


### PR DESCRIPTION
- see test and description
- bunyan changes their behaviour in 1.8.3, which we can't support right now
- this test will fail when we bump bunyan
