### PR TITLE
✨  get parent path

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,7 +1,22 @@
-var path = process.cwd().split('/');
-var alias = process.env.npm_package_alias || process.env.npm_package_name || path[path.length - 1];
+var utils = require('./utils');
 var debug = require('debug');
 
 module.exports = function initDebug(name) {
+    var path = utils.getParentPath();
+    var alias, pkg;
+
+    try {
+        pkg = require(path + '/package.json');
+
+        if (pkg.alias) {
+            alias = pkg.alias;
+        } else {
+            alias = pkg.name;
+        }
+
+    } catch (err) {
+        alias = 'undefined';
+    }
+
     return debug(alias + ':' + name);
-}
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,27 @@
+var findRoot = require('find-root');
+var caller = require('caller');
+
+/**
+ * caller dependency is able to detect the calling unit
+ * they are doing this with the trick of creating an error stack
+ * caller(2) means -> get me the previous calling unit
+ *
+ * Example Structure:
+ * Ghost
+ *    node_modules
+ *       ghost-ignition
+ *       passport-ghost
+ *
+ * Ghost uses ghost-ignition and passport-ghost uses ghost-ignition.
+ *
+ * If passport-ghost calls ghost-ignition, caller(2) would return the last caller of this module
+ * If Ghost calls ghost-ignition, caller(2) would return the last caller of this module
+ * And findRoot will be able to get the latest path with a valid package.json
+ */
+exports.getParentPath = function getParent() {
+    try {
+        return findRoot(caller(2));
+    } catch (err) {
+        return;
+    }
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/TryGhost/Ignition#readme",
   "dependencies": {
     "bunyan": "1.8.1",
+    "caller": "1.0.1",
     "debug": "2.2.0",
     "express": "4.14.0",
     "find-root": "1.0.0",


### PR DESCRIPTION
closes #9

With this util we are able to use ghost-ignition in multiple projects.
The util function is able to detect the last caller.
- this is used for now only for debug feature
- more later

It's hard to add tests for this util function. I've protected the feature by catching any error, so it won't crash.
