### PR TITLE
✨ Load config for top-level module ONLY

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,37 +1,38 @@
 var nconf = require('nconf');
 var fs = require('fs');
 var path = require('path');
-var findRoot = require('find-root');
-var defaults = {};
-var getParentPath = function (parent) {
-        if (!parent  || !parent.filename) {
-            return null;
-        }
+var debug = require('debug')('ignition:config');
+var config;
 
-        if (parent.filename.match(/ghost-ignition/gi)) {
-            return getParentPath(parent.parent);
-        }
+var setupConfig = function setupConfig() {
+    var env = require('./env');
+    var defaults = {};
+    var parentPath = process.cwd();
 
-        // finds the root with package.json based on a path
-        return findRoot(parent.filename);
-    };
-var parentPath = getParentPath(module.parent);
-var env = require('./env');
+    config = new nconf.Provider();
 
-if (parentPath && fs.existsSync(path.join(parentPath, 'config.example.json'))) {
-    defaults = require(path.join(parentPath, 'config.example.json'));
-}
+    if (parentPath && fs.existsSync(path.join(parentPath, 'config.example.json'))) {
+        defaults = require(path.join(parentPath, 'config.example.json'));
+    }
 
-nconf.set('NODE_ENV', env);
+    config.argv()
+        .env()
+        .file({
+            file: path.join(parentPath, 'config.' + env + '.json')
+        });
 
-nconf.argv()
-    .env()
-    .file({
-        file: path.join(parentPath, 'config.' + env + '.json')
-    });
+    config.set('NODE_ENV', env);
 
-nconf.defaults(defaults);
+    config.defaults(defaults);
+};
 
-// @TODO: this file gets cached after the first require, we need to redesign how we load the config
-// @TODO: for example: require('ghost-ignition').config()
-module.exports = nconf;
+/**
+ * The config object is cached, once it has been setup with the parent
+ */
+module.exports = function initConfig() {
+    if (!config) {
+         setupConfig();
+    }
+
+    return config;
+};

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -21,7 +21,7 @@ var setupConfig = function setupConfig() {
             file: path.join(parentPath, 'config.' + env + '.json')
         });
 
-    config.set('NODE_ENV', env);
+    config.set('env', env);
 
     config.defaults(defaults);
 };

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -2,11 +2,11 @@ var utils = require('./utils');
 var debug = require('debug');
 
 module.exports = function initDebug(name) {
-    var path = utils.getParentPath();
+    var parentPath = utils.getParentPath();
     var alias, pkg;
 
     try {
-        pkg = require(path + '/package.json');
+        pkg = require(parentPath + '/package.json');
 
         if (pkg.alias) {
             alias = pkg.alias;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,20 +1,20 @@
-var config = require('./config');
 var debug = require('./debug')('server');
 var http = require('http');
 
 var server;
+var port;
 
 /**
  * Get port from nconf
  */
-
-var port = normalizePort(config.get('port'));
 
 var start = function start(app) {
     /**
      * Create HTTP server.
      */
 
+    var config = require('./config')();
+    port = normalizePort(config.get('port'));
     server = http.createServer(app);
 
     /**


### PR DESCRIPTION
This PR fixes the issues in #3 as best as I can determine.

This PR is a breaking change to the API, meaning it will need to be shipped as ignition 2.0.0!
- By wrapping the config loading into a caching function, we ONLY load nconf when it is needed.
- So far, there is no case where a submodule requires configuration. Therefore, we don't support this usecase
- If we needed to support this usecase, it could be done by passing an argument to the `config()` function, and effectively "naming" the config instance. We could then cache more than one config object. This seems like way too much for a usecase we don't need.
- Because we are no longer EVER loading nconf from within a subdependency, we no longer need to do extra work to handle where the config comes from - it comes from `process.cwd`. 


---

closes #3
- We call config() to initialise the configuration, so that subdependencies don't needlessly call nconf
- The most common first-caller, is `lib/server.js`
- As submodules no longer try to load config, we can use `process.cwd()` again
- This will only work if sub-dependencies DO NOT require config (currently always true)
