### PR TITLE
🎨  re-add InternalServerError

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -56,6 +56,14 @@ function IgnitionError(options) {
 
 // jscs:disable
 var errors = {
+    InternalServerError: function InternalServerError(options) {
+        IgnitionError.call(this, _.merge({
+            statusCode: 500,
+            level: 'critical',
+            errorType: 'InternalServerError',
+            message: 'The server has encountered an error.'
+        }, options));
+    },
     IncorrectUsageError: function IncorrectUsageError(options) {
         IgnitionError.call(this, _.merge({
             statusCode: 400,


### PR DESCRIPTION
closes #12

- simply re-added the internal server error
- background: it's confusing to create an internal server error by calling `new errors.IgnitionError()`