### PR TITLE
🐛  transport file path

### DIFF
--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -70,7 +70,7 @@ GhostLogger.prototype.setFileStream = function () {
         log: bunyan.createLogger({
             name: 'Log',
             streams: [{
-                path: this.path + this.domain + '_' + '.error.log',
+                path: this.path + this.domain + '_' + this.env + '.error.log',
                 level: 'error'
             }],
             serializers: this.serializers
@@ -82,7 +82,7 @@ GhostLogger.prototype.setFileStream = function () {
         log: bunyan.createLogger({
             name: 'Log',
             streams: [{
-                path: this.path + this.domain + '_' + '.log',
+                path: this.path + this.domain + '_' + this.env + '.log',
                 level: this.level
             }],
             serializers: this.serializers
@@ -96,7 +96,7 @@ GhostLogger.prototype.setFileStream = function () {
                 name: 'Log',
                 streams: [{
                     type: 'rotating-file',
-                    path: this.path + this.domain + '_' + '.error.log',
+                    path: this.path + this.domain + '_' + this.env + '.error.log',
                     period: this.rotation.period,
                     count: this.rotation.count,
                     level: this.level


### PR DESCRIPTION
closes #13
- env param was missing, that's why the filename was `localhost_.log`
- now it looks like localhost_development.log or example_com_production.errors.log

Even it's recommended using file transport in production, it might be very helpful to show the env in the filename. Imagine people would like to run their blog in development to test logging into file.