### PR TITLE
🎨 lazily require modules in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
-    config: require('./lib/config'),
-    debug:  require('./lib/debug'),
-    errors: require('./lib/errors'),
-    server: require('./lib/server'),
-    logging: require('./lib/logging')
+    get config() {return require('./lib/config');},
+    get debug() {return require('./lib/debug');},
+    get errors() {return require('./lib/errors');},
+    get server() {return require('./lib/server');},
+    get logging() {return require('./lib/logging');}
 };


### PR DESCRIPTION
This uses object getters to load ignition modules, rather than requiring all of them. This should improve performance a bit as dependencies which only require 1 thing from ghost-ignition will not be forced to load all of them.