### PR TITLE
Config: Add support for scripts in subdirs

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,12 +1,13 @@
 var nconf = require('nconf');
 var fs = require('fs');
 var path = require('path');
+var utils = require('../utils');
 var config;
 
 var setupConfig = function setupConfig() {
     var env = require('./env');
     var defaults = {};
-    var parentPath = process.cwd();
+    var parentPath = utils.getCWDRoot();
 
     config = new nconf.Provider();
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -27,9 +27,10 @@ var setupConfig = function setupConfig() {
 
 /**
  * The config object is cached, once it has been setup with the parent
+ * @param {boolean} noCache - used for tests only, to reinit the cache on every call
  */
-module.exports = function initConfig() {
-    if (!config) {
+module.exports = function initConfig(noCache) {
+    if (!config || noCache) {
          setupConfig();
     }
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -2,7 +2,7 @@ var utils = require('./utils');
 var debug = require('debug');
 
 module.exports = function initDebug(name) {
-    var parentPath = utils.getParentPath();
+    var parentPath = utils.getCallerRoot();
     var alias, pkg;
 
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,12 @@ var findRoot = require('find-root');
 var caller = require('caller');
 
 /**
+ * getCallerRoot
+ *
+ * Used by debug,
+ * because we want to find the root (where a package.json exists) nearest to the calling module.
+ * So that debug messages are output relative to the CALLER module
+ *
  * caller dependency is able to detect the calling unit
  * they are doing this with the trick of creating an error stack
  * caller(2) means -> get me the previous calling unit
@@ -18,7 +24,7 @@ var caller = require('caller');
  * If Ghost calls ghost-ignition, caller(2) would return the last caller of this module
  * And findRoot will be able to get the latest path with a valid package.json
  */
-exports.getParentPath = function getParent() {
+exports.getCallerRoot = function getCallerRoot() {
     try {
         return findRoot(caller(2));
     } catch (err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,3 +31,25 @@ exports.getCallerRoot = function getCallerRoot() {
         return;
     }
 };
+
+/**
+ * getCWDRoot
+ *
+ * Used by config,
+ * because we want to find the root (where a package.json exists) nearest to the current working directory
+ * So that configuration uses the config file AT the CWD, or at the project root of the CWD
+ *
+ * process.cwd() is the path from which `node` was called
+ * usually, the root of a project, e.g. the same level as where package.json,
+ * config.*.json and node_modules folder would be found.
+ *
+ * However, in some cases, the CWD may be deeper in the project,
+ * e.g. if using a script, or using a childprocess.
+ */
+exports.getCWDRoot = function getCWDRoot() {
+    try {
+        return findRoot(process.cwd());
+    } catch (err) {
+        return;
+    }
+}

--- a/test/config-fixtures/config.example.json
+++ b/test/config-fixtures/config.example.json
@@ -1,0 +1,4 @@
+{
+  "test": "root-config",
+  "should-be-used": true
+}

--- a/test/config-fixtures/scripts/config.example.json
+++ b/test/config-fixtures/scripts/config.example.json
@@ -1,0 +1,4 @@
+{
+  "test": "scripts-config",
+  "should-be-used": false
+}

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,48 @@
+// Test requirements
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var join = require('path').join;
+
+var initConfig = require('../lib/config');
+
+var sandbox = sinon.sandbox.create();
+
+describe('Config', function () {
+    var processCWDStub;
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    function fixturePath(path) {
+        return join(__dirname, 'config-fixtures', path || '');
+    }
+
+    it('Ignition does NOT have config', function () {
+        processCWDStub = sandbox.spy(process, 'cwd');
+        var config = initConfig(true);
+
+        expect(processCWDStub.firstCall.returnValue).to.match(/Ignition$/);
+        expect(config.get('test')).to.be.undefined;
+        expect(config.get('should-be-used')).to.be.undefined;
+    });
+
+    it('loads root config when called by root JS file', function () {
+        processCWDStub = sandbox.stub(process, 'cwd').returns(fixturePath());
+        var config = initConfig(true);
+
+        expect(config.stores.file.file).to.match(/Ignition\/test\/config-fixtures\/config\.development\.json$/);
+        expect(config.get('test')).to.equal('root-config');
+        expect(config.get('should-be-used')).to.be.true;
+    });
+
+    // TODO: make it possible for this to pass
+    it.skip('loads root config when called from a script in a subdirectory', function () {
+        processCWDStub = sandbox.stub(process, 'cwd').returns(fixturePath('scripts'));
+        var config = initConfig(true);
+
+        expect(config.stores.file.file).to.match(/Ignition\/test\/config-fixtures\/config\.development\.json$/);
+        expect(config.get('test')).to.equal('root-config');
+        expect(config.get('should-be-used')).to.be.true;
+    });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -36,8 +36,7 @@ describe('Config', function () {
         expect(config.get('should-be-used')).to.be.true;
     });
 
-    // TODO: make it possible for this to pass
-    it.skip('loads root config when called from a script in a subdirectory', function () {
+    it('loads root config when called from a script in a subdirectory', function () {
         processCWDStub = sandbox.stub(process, 'cwd').returns(fixturePath('scripts'));
         var config = initConfig(true);
 


### PR DESCRIPTION
See #43 for a detailed explanation.

This is a fix for problem 1, in which scripts that live in subfolders don't get any config unless they are executed from root.

In this PR:

- adds tests for config, making it possible to test by adding a noCache option & adding a bunch of fixtures.
- adds and skips a test for the case I'm running into which fails
- renames the `getParentPath` util used by debug to `getCallerRoot`, and adds more extensive explanations of the logic
- adds a new `getCWDRoot` method, which gets the root or parent path relative to `process.cwd()`
- updates config & unskips the test

As far as I can figure out, this change does NOT change any of the existing cases. However, I'd recommend this goes out as 2.9.0 and isn't upgraded in Ghost until post 1.0 😬 
