### PR TITLE
✨ Added status code colours to prettysteam output

### DIFF
--- a/lib/logging/PrettyStream.js
+++ b/lib/logging/PrettyStream.js
@@ -47,6 +47,16 @@ function colorize(color, value) {
     return '\x1B[' + _private.colors[color][0] + 'm' + value + '\x1B[' + _private.colors[color][1] + 'm';
 }
 
+function statusCode(status) {
+    var color = status >= 500 ? 'red'
+        : status >= 400 ? 'yellow'
+        : status >= 300 ? 'cyan'
+        : status >= 200 ? 'green'
+        : 0 // no color
+
+    return colorize(color, status);
+}
+
 class PrettyStream extends Transform {
     constructor(options) {
         options = options || {};
@@ -113,7 +123,7 @@ class PrettyStream extends Transform {
                     time,
                     data.req.method.toUpperCase(),
                     data.req.originalUrl,
-                    data.res.statusCode,
+                    statusCode(data.res.statusCode),
                     data.res.responseTime
                 );
             } catch (err) {

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -285,7 +285,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('\u001b[36mINFO\u001b[39m [2016-07-01 00:00:00] "GET /test" 200 39ms\n');
+                    data.should.eql('\u001b[36mINFO\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[32m200\u001b[39m 39ms\n');
                     done();
                 };
 
@@ -314,7 +314,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" 400 39ms\n\u001b[31m\n\u001b[31mMESSAGE: message\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n');
+                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[33m400\u001b[39m 39ms\n\u001b[31m\n\u001b[31mMESSAGE: message\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n');
                     done();
                 };
 
@@ -390,7 +390,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('\u001b[36mINFO\u001b[39m [2016-07-01 00:00:00] "GET /test" 200 39ms\n\u001b[90m\n\u001b[33mREQ\u001b[39m\n\u001b[32mip: \u001b[39m         127.0.01\n\u001b[32moriginalUrl: \u001b[39m/test\n\u001b[32mmethod: \u001b[39m     GET\n\u001b[32mbody: \u001b[39m\n  \u001b[32ma: \u001b[39mb\n\n\u001b[33mRES\u001b[39m\n\u001b[32mresponseTime: \u001b[39m39ms\n\u001b[39m\n');
+                    data.should.eql('\u001b[36mINFO\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[32m200\u001b[39m 39ms\n\u001b[90m\n\u001b[33mREQ\u001b[39m\n\u001b[32mip: \u001b[39m         127.0.01\n\u001b[32moriginalUrl: \u001b[39m/test\n\u001b[32mmethod: \u001b[39m     GET\n\u001b[32mbody: \u001b[39m\n  \u001b[32ma: \u001b[39mb\n\n\u001b[33mRES\u001b[39m\n\u001b[32mresponseTime: \u001b[39m39ms\n\u001b[39m\n');
                     done();
                 };
 
@@ -420,7 +420,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" 400 39ms\n\u001b[31m\n\u001b[31mMESSAGE: Hey Jude!\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n\u001b[90m\n\u001b[33mREQ\u001b[39m\n\u001b[32moriginalUrl: \u001b[39m/test\n\u001b[32mmethod: \u001b[39m     GET\n\u001b[32mbody: \u001b[39m\n  \u001b[32ma: \u001b[39mb\n\n\u001b[33mRES\u001b[39m\n\u001b[32mresponseTime: \u001b[39m39ms\n\u001b[39m\n');
+                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[33m400\u001b[39m 39ms\n\u001b[31m\n\u001b[31mMESSAGE: Hey Jude!\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n\u001b[90m\n\u001b[33mREQ\u001b[39m\n\u001b[32moriginalUrl: \u001b[39m/test\n\u001b[32mmethod: \u001b[39m     GET\n\u001b[32mbody: \u001b[39m\n  \u001b[32ma: \u001b[39mb\n\n\u001b[33mRES\u001b[39m\n\u001b[32mresponseTime: \u001b[39m39ms\n\u001b[39m\n');
                     done();
                 };
 


### PR DESCRIPTION
With this PR + https://github.com/TryGhost/Ghost/pull/8850, the output looks like:

![](https://puu.sh/x34Lu.png)

no issue

- Add colors for status code, the same as morgan
- This makes the status code output in a colour, exactly the same as LTS