### PR TITLE
🛠 Used full paths for tools in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Basic configuration and tooling shared across applications",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint lib test",
-    "test": "npm run lint && mocha -- $(find test -name '*.test.js')"
+    "lint": "./node_modules/.bin/eslint lib test",
+    "test": "npm run lint && ./node_modules/.bin/mocha -- $(find test -name '*.test.js')"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
no issue

- This means I don't have to have mocha & eslint installed globally