### PR TITLE
✨ Exported the debug library for reuse

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -20,3 +20,5 @@ module.exports = function initDebug(name) {
 
     return debug(alias + ':' + name);
 };
+
+module.exports._base = debug;


### PR DESCRIPTION
no issue

- In Ghost, we use the debug module directly sometimes
- This exports the debug module so we can use it