### PR TITLE
Property normalisation for error properties that could contain objects

### DIFF
--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -234,11 +234,11 @@ class GhostLogger {
                     statusCode: err.statusCode,
                     level: err.level,
                     message: err.message,
-                    context: err.context,
+                    context: jsonStringifySafe(err.context),
                     help: err.help,
                     stack: err.stack,
                     hideStack: err.hideStack,
-                    errorDetails: err.errorDetails
+                    errorDetails: jsonStringifySafe(err.errorDetails)
                 };
             }
         };


### PR DESCRIPTION
Normalised properties in error serializer that might be passed as objects

closes #63

- Added stringification for context and errorDetails error object properties