### PR TITLE
Removed override of error code property

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -55,6 +55,10 @@ function IgnitionError(options) {
                 return;
             }
 
+            if (property === 'code') {
+              self[property] = self[property] || options.err[property];
+            }
+
             if (property === 'stack') {
                 self[property] += '\n\n' + options.err[property];
                 return;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -55,6 +55,7 @@ function IgnitionError(options) {
                 return;
             }
 
+            // CASE: `code` should put options as priority over err
             if (property === 'code') {
               self[property] = self[property] || options.err[property];
             }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -51,7 +51,7 @@ function IgnitionError(options) {
         }
 
         Object.getOwnPropertyNames(options.err).forEach(function (property) {
-            if (['errorType', 'name', 'statusCode', 'message', 'level', 'code'].indexOf(property) !== -1) {
+            if (['errorType', 'name', 'statusCode', 'message', 'level'].indexOf(property) !== -1) {
                 return;
             }
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -51,7 +51,7 @@ function IgnitionError(options) {
         }
 
         Object.getOwnPropertyNames(options.err).forEach(function (property) {
-            if (['errorType', 'name', 'statusCode', 'message', 'level'].indexOf(property) !== -1) {
+            if (['errorType', 'name', 'statusCode', 'message', 'level', 'code'].indexOf(property) !== -1) {
                 return;
             }
 


### PR DESCRIPTION
This refs the conversation here: https://github.com/TryGhost/Ghost/pull/10415

The problem is that when supplying a `code` to an Ignition error, it might not always set the code you ask