### PR TITLE
Removed 'empty' for absent error properties

### DIFF
--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -234,11 +234,11 @@ class GhostLogger {
                     statusCode: err.statusCode,
                     level: err.level,
                     message: err.message,
-                    context: jsonStringifySafe(err.context) || 'empty',
-                    help: jsonStringifySafe(err.help) || 'empty',
+                    context: jsonStringifySafe(err.context),
+                    help: jsonStringifySafe(err.help),
                     stack: err.stack,
                     hideStack: err.hideStack,
-                    errorDetails: jsonStringifySafe(err.errorDetails) || 'empty'
+                    errorDetails: jsonStringifySafe(err.errorDetails)
                 };
             }
         };

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -247,11 +247,11 @@ describe('Logging', function () {
                 should.equal(data.err.statusCode, err.statusCode);
                 data.err.level.should.eql(err.level);
                 data.err.message.should.eql(err.message);
-                should.equal(data.err.context, 'empty');
-                should.equal(data.err.help, 'empty');
+                should.equal(data.err.context, undefined);
+                should.equal(data.err.help, undefined);
                 should.exist(data.err.stack);
                 should.equal(data.err.hideStack, undefined);
-                should.equal(data.err.errorDetails, 'empty');
+                should.equal(data.err.errorDetails, undefined);
                 done();
             });
 


### PR DESCRIPTION
closes #66

The change needs a second pair of eyes for testing. After trying different property types and sending empty values loggly index doesn't seem to break anymore.