### PR TITLE
Improved error output formatting

### DIFF
--- a/lib/logging/PrettyStream.js
+++ b/lib/logging/PrettyStream.js
@@ -42,8 +42,12 @@ var moment = require('moment'),
         }
     };
 
-function colorize(color, value) {
-    return '\x1B[' + _private.colors[color][0] + 'm' + value + '\x1B[' + _private.colors[color][1] + 'm';
+function colorize(colors, value) {
+    if (isArray(colors)) {
+        return colors.reduce((acc, color) => colorize(color, acc), value);
+    } else {
+        return '\x1B[' + _private.colors[colors][0] + 'm' + value + '\x1B[' + _private.colors[colors][1] + 'm';
+    }
 }
 
 function statusCode(status) {
@@ -137,19 +141,11 @@ class PrettyStream extends Transform {
                 if (isObject(value) && value.message && value.stack) {
                     var error = '\n';
 
-                    if (value.name) {
-                        error += colorize(_private.colorForLevel[data.level], 'NAME: ' + value.name) + '\n';
+                    if (value.errorType) {
+                        error += colorize(_private.colorForLevel[data.level], 'Type: ' + value.errorType) + '\n';
                     }
 
-                    if (value.code) {
-                        error += colorize(_private.colorForLevel[data.level], 'CODE: ' + value.code) + '\n';
-                    }
-
-                    error += colorize(_private.colorForLevel[data.level], 'MESSAGE: ' + value.message) + '\n\n';
-
-                    if (value.level) {
-                        error += colorize('white', 'level:') + colorize('white', value.level) + '\n\n';
-                    }
+                    error += colorize(_private.colorForLevel[data.level], value.message) + '\n\n';
 
                     if (value.context) {
                         error += colorize('white', value.context) + '\n';
@@ -159,17 +155,36 @@ class PrettyStream extends Transform {
                         error += colorize('yellow', value.help) + '\n';
                     }
 
+                    if (value.id) {
+                        error += colorize(['white', 'bold'], 'Error ID:') + '\n';
+                        error += '    ' + colorize('grey', value.id) + '\n\n';
+                    }
+                    if (value.code) {
+                        error += colorize(['white', 'bold'], 'Error Code: ') + '\n';
+                        error += '    ' + colorize('grey', value.code) + '\n\n';
+                    }
+
                     if (value.errorDetails) {
-                        error += colorize(
-                                _private.colorForLevel[data.level],
-                                'ERROR DETAILS:\n' + prettyjson.render(isArray(value.errorDetails) ? value.errorDetails[0] : value.errorDetails, {
-                                    noColor: true
-                                }, 4)
-                            ) + '\n\n';
+                        let details = value.errorDetails;
+
+                        try {
+                            const jsonDetails = JSON.parse(value.errorDetails);
+                            details = isArray(jsonDetails) ? jsonDetails[0] :jsonDetails;
+                        } catch (err) {
+                            // no need for special handling as we default to unparsed 'errorDetails'
+                        }
+
+                        const pretty = prettyjson.render(details, {
+                            noColor: true
+                        }, 4);
+
+                        error += colorize(['white', 'bold'], 'Details:') + '\n';
+                        error += colorize('grey', pretty) + '\n\n';
                     }
 
                     if (value.stack && !value.hideStack) {
-                        error += colorize('white', value.stack) + '\n';
+                        error += colorize('grey', '----------------------------------------') + '\n\n';
+                        error += colorize('grey', value.stack) + '\n';
                     }
 
                     output += format('%s\n', colorize(_private.colorForLevel[data.level], error));

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -330,7 +330,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mCODE: HEY_JUDE\u001b[39m\n\u001b[31mMESSAGE: Hey Jude!\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n');
+                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mHey Jude!\u001b[39m\n\n\u001b[1m\u001b[37mError Code: \u001b[39m\u001b[22m\n    \u001b[90mHEY_JUDE\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n');
                     done();
                 };
 
@@ -383,7 +383,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[33m400\u001b[39m 39ms\n\u001b[31m\n\u001b[31mMESSAGE: message\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n');
+                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[33m400\u001b[39m 39ms\n\u001b[31m\n\u001b[31mmessage\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n');
                     done();
                 };
 
@@ -437,7 +437,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mMESSAGE: Hey Jude!\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n\u001b[90m\u001b[39m\n');
+                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mHey Jude!\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n\u001b[90m\u001b[39m\n');
                     done();
                 };
 
@@ -489,7 +489,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[33m400\u001b[39m 39ms\n\u001b[31m\n\u001b[31mMESSAGE: Hey Jude!\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n\u001b[90m\n\u001b[33mREQ\u001b[39m\n\u001b[32moriginalUrl: \u001b[39m/test\n\u001b[32mmethod: \u001b[39m     GET\n\u001b[32mbody: \u001b[39m\n  \u001b[32ma: \u001b[39mb\n\n\u001b[33mRES\u001b[39m\n\u001b[32mresponseTime: \u001b[39m39ms\n\u001b[39m\n');
+                    data.should.eql('\u001b[31mERROR\u001b[39m [2016-07-01 00:00:00] "GET /test" \u001b[33m400\u001b[39m 39ms\n\u001b[31m\n\u001b[31mHey Jude!\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n\u001b[90m\n\u001b[33mREQ\u001b[39m\n\u001b[32moriginalUrl: \u001b[39m/test\n\u001b[32mmethod: \u001b[39m     GET\n\u001b[32mbody: \u001b[39m\n  \u001b[32ma: \u001b[39mb\n\n\u001b[33mRES\u001b[39m\n\u001b[32mresponseTime: \u001b[39m39ms\n\u001b[39m\n');
                     done();
                 };
 
@@ -516,13 +516,13 @@ describe('Logging', function () {
                 }));
             });
 
-            it('data.err contains error details', function (done) {
+            it('data.err contains error details && meta fields', function (done) {
                 var ghostPrettyStream = new PrettyStream({mode: 'long'});
                 var writeStream = new Writable();
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mMESSAGE: Hey Jude!\u001b[39m\n\n\u001b[31mERROR DETAILS:\n    level:    error\n    rule:     Templates must contain valid Handlebars.\n    failures: \n      - \n        ref:     default.hbs\n        message: Missing helper: "image"\n    code:     GS005-TPL-ERR\u001b[39m\n\n\u001b[37mstack\u001b[39m\n\u001b[39m\n\u001b[90m\u001b[39m\n');
+                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mType: ValidationError\u001b[39m\n\u001b[31mHey Jude!\u001b[39m\n\n\u001b[37m{"a":"b"}\u001b[39m\n\u001b[33mCheck documentation at https://docs.ghost.org/\u001b[39m\n\u001b[1m\u001b[37mError ID:\u001b[39m\u001b[22m\n    \u001b[90me8546680-401f-11e9-99a7-ed7d6251b35c\u001b[39m\n\n\u001b[1m\u001b[37mDetails:\u001b[39m\u001b[22m\n\u001b[90m    level:    error\n    rule:     Templates must contain valid Handlebars.\n    failures: \n      - \n        ref:     default.hbs\n        message: Missing helper: "image"\n    code:     GS005-TPL-ERR\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n\u001b[90m\u001b[39m\n');
                     done();
                 };
 
@@ -534,12 +534,16 @@ describe('Logging', function () {
                     err: {
                         message: 'Hey Jude!',
                         stack: 'stack',
-                        errorDetails: [{
+                        errorType: 'ValidationError',
+                        id: 'e8546680-401f-11e9-99a7-ed7d6251b35c',
+                        context: JSON.stringify({a: 'b'}),
+                        help: 'Check documentation at https://docs.ghost.org/',
+                        errorDetails: JSON.stringify([{
                             level: 'error',
                             rule: 'Templates must contain valid Handlebars.',
                             failures: [{ref: 'default.hbs', message: 'Missing helper: "image"'}],
                             code: 'GS005-TPL-ERR'
-                        }]
+                        }])
                     }
                 }));
             });


### PR DESCRIPTION
closes #69 

@peterzimon With these changes, the output of for an error looks like this in Ubuntu terminal:

![screenshot from 2019-03-06 13-32-06](https://user-images.githubusercontent.com/675397/53858431-2887f380-4015-11e9-9cb3-0b4b355d27f6.png)

and another variation of different error which is just logged (doesn't have the path and time of response):
![screenshot from 2019-03-06 22-56-12](https://user-images.githubusercontent.com/675397/53890403-1f257800-4063-11e9-99d2-86b39d0a8dbe.png)

The coloring is heavily dependant on the environment, but kept it in similar style we had it before with some boldening added as in the design. Let me know if you spot anything missint or have any other feedback :+1: 
