### PR TITLE
🐛 Fix handling of logging with string and object arguments

### DIFF
--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -306,34 +306,30 @@ class GhostLogger {
      * logging.info({}, {}) --> is one object
      * logging.error(new Error()) --> is {err: new Error()}
      */
-    log(type, args) {
-        let modifiedArguments;
+     log(type, args) {
+         let modifiedMessages = [];
+         let modifiedObject = {};
+         let modifiedArguments = [];
 
-        each(args, function (value) {
-            if (value instanceof Error) {
-                if (!modifiedArguments) {
-                    modifiedArguments = {};
-                }
+         each(args, function (value) {
+             if (value instanceof Error) {
+                 modifiedObject.err = value;
+             } else if (isObject(value)) {
+               var keys = Object.keys(value);
+                 each(keys, function (key) {
+                     modifiedObject[key] = value[key];
+                 });
+             } else {
+                 modifiedMessages.push(value);
+             }
+         });
 
-                modifiedArguments.err = value;
-            } else if (isObject(value)) {
-                if (!modifiedArguments) {
-                    modifiedArguments = {};
-                }
-
-                var keys = Object.keys(value);
-                each(keys, function (key) {
-                    modifiedArguments[key] = value[key];
-                });
-            } else {
-                if (!modifiedArguments) {
-                    modifiedArguments = '';
-                }
-
-                modifiedArguments += value;
-                modifiedArguments += ' ';
-            }
-        });
+         if (modifiedObject.err) {
+             modifiedMessages.push(modifiedObject.err.message);
+         }
+         
+         modifiedArguments.push(modifiedObject);
+         modifiedArguments.push(...modifiedMessages);
 
         each(this.streams, (logger) => {
             // If we have both a stdout and a stderr stream, don't log errors to stdout
@@ -363,11 +359,11 @@ class GhostLogger {
              * https://github.com/moll/json-stringify-safe
              */
             if (logger.match && type === 'error') {
-                if (new RegExp(logger.match).test(jsonStringifySafe(modifiedArguments.err || null).replace(/"/g, ''))) {
-                    logger.log[type](modifiedArguments);
+                if (new RegExp(logger.match).test(jsonStringifySafe(modifiedArguments[0].err || null).replace(/"/g, ''))) {
+                    logger.log[type](...modifiedArguments);
                 }
             } else {
-                logger.log[type](modifiedArguments);
+                logger.log[type](...modifiedArguments);
             }
         });
     }

--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -2,6 +2,7 @@ const each = require('lodash/each');
 const upperFirst = require('lodash/upperFirst');
 const toArray = require('lodash/toArray');
 const isObject = require('lodash/isObject');
+const isEmpty = require('lodash/isEmpty');
 const includes = require('lodash/includes');
 const bunyan = require('bunyan');
 const fs = require('fs-extra');
@@ -306,30 +307,31 @@ class GhostLogger {
      * logging.info({}, {}) --> is one object
      * logging.error(new Error()) --> is {err: new Error()}
      */
-     log(type, args) {
-         let modifiedMessages = [];
-         let modifiedObject = {};
-         let modifiedArguments = [];
+    log(type, args) {
+        let modifiedMessages = [];
+        let modifiedObject = {};
+        let modifiedArguments = [];
 
-         each(args, function (value) {
-             if (value instanceof Error) {
-                 modifiedObject.err = value;
-             } else if (isObject(value)) {
-               var keys = Object.keys(value);
-                 each(keys, function (key) {
-                     modifiedObject[key] = value[key];
-                 });
-             } else {
-                 modifiedMessages.push(value);
-             }
-         });
+        each(args, function (value) {
+           if (value instanceof Error) {
+               modifiedObject.err = value;
+           } else if (isObject(value)) {
+               each(Object.keys(value), function (key) {
+                   modifiedObject[key] = value[key];
+               });
+           } else {
+               modifiedMessages.push(value);
+           }
+        });
 
-         if (modifiedObject.err) {
-             modifiedMessages.push(modifiedObject.err.message);
-         }
-         
-         modifiedArguments.push(modifiedObject);
-         modifiedArguments.push(...modifiedMessages);
+        if (!isEmpty(modifiedObject)) {
+           if (modifiedObject.err) {
+               modifiedMessages.push(modifiedObject.err.message);
+           }
+           modifiedArguments.push(modifiedObject);
+        }
+
+        modifiedArguments.push(...modifiedMessages);
 
         each(this.streams, (logger) => {
             // If we have both a stdout and a stderr stream, don't log errors to stdout

--- a/lib/logging/PrettyStream.js
+++ b/lib/logging/PrettyStream.js
@@ -4,6 +4,7 @@ var moment = require('moment'),
     prettyjson = require('prettyjson'),
     each = require('lodash/each'),
     omit = require('lodash/omit'),
+    get = require('lodash/get'),
     isArray = require('lodash/isArray'),
     isEmpty = require('lodash/isEmpty'),
     isObject = require('lodash/isObject'),
@@ -107,9 +108,9 @@ class PrettyStream extends Transform {
                 time,
                 logLevel,
                 data.req.method.toUpperCase(),
-                data.req.originalUrl,
-                statusCode(data.res.statusCode),
-                data.res.responseTime
+                get(data, 'req.originalUrl'),
+                statusCode(get(data, 'res.statusCode')),
+                get(data, 'res.responseTime')
             );
         }
         else if (data.msg === undefined) {

--- a/lib/logging/PrettyStream.js
+++ b/lib/logging/PrettyStream.js
@@ -102,118 +102,108 @@ class PrettyStream extends Transform {
 
         logLevel = '\x1B[' + codes[0] + 'm' + logLevel + '\x1B[' + codes[1] + 'm';
 
-        // CASE: bunyan passes each plain string/integer as `msg` attribute (logging.info('Hey!'))
-        // CASE: bunyan extended this by figuring out a message in an error object (new Error('message'))
-        if (data.msg && !data.err) {
-            bodyPretty += data.msg;
-
-            output += format('[%s] %s %s\n',
+        if (data.req) {
+            output += format('[%s] %s "%s %s" %s %s\n',
                 time,
                 logLevel,
-                bodyPretty
+                data.req.method.toUpperCase(),
+                data.req.originalUrl,
+                statusCode(data.res.statusCode),
+                data.res.responseTime
             );
         }
-        // CASE: log objects in pretty JSON format
+        else if (data.msg === undefined) {
+            output += format('[%s] %s\n',
+                time,
+                logLevel
+            );
+        }
         else {
-            // common log format:
-            // 127.0.0.1 user-identifier user-id [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+            bodyPretty += data.msg;
+            output += format('[%s] %s %s\n',
+               time,
+               logLevel,
+               bodyPretty
+            );
+        }
 
-            // if all values are available we log in common format
-            // can be extended to define from outside, but not important
-            try {
-                output += format('[%s] %s "%s %s" %s %s\n',
-                    time,
-                    logLevel,
-                    data.req.method.toUpperCase(),
-                    data.req.originalUrl,
-                    statusCode(data.res.statusCode),
-                    data.res.responseTime
-                );
-            } catch (err) {
-                output += format('[%s] %s\n',
-                    time,
-                    logLevel
-                );
-            }
+        each(omit(data, ['time', 'level', 'name', 'hostname', 'pid', 'v', 'msg']), function (value, key) {
+            // we always output errors for now
+            if (isObject(value) && value.message && value.stack) {
+                var error = '\n';
 
-            each(omit(data, ['time', 'level', 'name', 'hostname', 'pid', 'v', 'msg']), function (value, key) {
-                // we always output errors for now
-                if (isObject(value) && value.message && value.stack) {
-                    var error = '\n';
-
-                    if (value.errorType) {
-                        error += colorize(_private.colorForLevel[data.level], 'Type: ' + value.errorType) + '\n';
-                    }
-
-                    error += colorize(_private.colorForLevel[data.level], value.message) + '\n\n';
-
-                    if (value.context) {
-                        error += colorize('white', value.context) + '\n';
-                    }
-
-                    if (value.help) {
-                        error += colorize('yellow', value.help) + '\n';
-                    }
-
-                    if (value.context || value.help) {
-                        error += '\n';
-                    }
-
-                    if (value.id) {
-                        error += colorize(['white', 'bold'], 'Error ID:') + '\n';
-                        error += '    ' + colorize('grey', value.id) + '\n\n';
-                    }
-
-                    if (value.code) {
-                        error += colorize(['white', 'bold'], 'Error Code: ') + '\n';
-                        error += '    ' + colorize('grey', value.code) + '\n\n';
-                    }
-
-                    if (value.errorDetails) {
-                        let details = value.errorDetails;
-
-                        try {
-                            const jsonDetails = JSON.parse(value.errorDetails);
-                            details = isArray(jsonDetails) ? jsonDetails[0] :jsonDetails;
-                        } catch (err) {
-                            // no need for special handling as we default to unparsed 'errorDetails'
-                        }
-
-                        const pretty = prettyjson.render(details, {
-                            noColor: true
-                        }, 4);
-
-                        error += colorize(['white', 'bold'], 'Details:') + '\n';
-                        error += colorize('grey', pretty) + '\n\n';
-                    }
-
-                    if (value.stack && !value.hideStack) {
-                        error += colorize('grey', '----------------------------------------') + '\n\n';
-                        error += colorize('grey', value.stack) + '\n';
-                    }
-
-                    output += format('%s\n', colorize(_private.colorForLevel[data.level], error));
+                if (value.errorType) {
+                    error += colorize(_private.colorForLevel[data.level], 'Type: ' + value.errorType) + '\n';
                 }
-                else if (isObject(value)) {
-                    bodyPretty += '\n' + colorize('yellow', key.toUpperCase()) + '\n';
 
-                    var sanitized = {};
+                error += colorize(_private.colorForLevel[data.level], value.message) + '\n\n';
 
-                    each(value, function (innerValue, innerKey) {
-                        if (!isEmpty(innerValue)) {
-                            sanitized[innerKey] = innerValue;
-                        }
-                    });
-
-                    bodyPretty += prettyjson.render(sanitized, {}) + '\n';
-                } else {
-                    bodyPretty += prettyjson.render(value, {}) + '\n';
+                if (value.context) {
+                    error += colorize('white', value.context) + '\n';
                 }
-            });
 
-            if (this.mode !== 'short') {
-                output += format('%s\n', colorize('grey', bodyPretty));
+                if (value.help) {
+                    error += colorize('yellow', value.help) + '\n';
+                }
+
+                if (value.context || value.help) {
+                    error += '\n';
+                }
+
+                if (value.id) {
+                    error += colorize(['white', 'bold'], 'Error ID:') + '\n';
+                    error += '    ' + colorize('grey', value.id) + '\n\n';
+                }
+
+                if (value.code) {
+                    error += colorize(['white', 'bold'], 'Error Code: ') + '\n';
+                    error += '    ' + colorize('grey', value.code) + '\n\n';
+                }
+
+                if (value.errorDetails) {
+                    let details = value.errorDetails;
+
+                    try {
+                        const jsonDetails = JSON.parse(value.errorDetails);
+                        details = isArray(jsonDetails) ? jsonDetails[0] :jsonDetails;
+                    } catch (err) {
+                        // no need for special handling as we default to unparsed 'errorDetails'
+                    }
+
+                    const pretty = prettyjson.render(details, {
+                        noColor: true
+                    }, 4);
+
+                    error += colorize(['white', 'bold'], 'Details:') + '\n';
+                    error += colorize('grey', pretty) + '\n\n';
+                }
+
+                if (value.stack && !value.hideStack) {
+                    error += colorize('grey', '----------------------------------------') + '\n\n';
+                    error += colorize('grey', value.stack) + '\n';
+                }
+
+                output += format('%s\n', colorize(_private.colorForLevel[data.level], error));
             }
+            else if (isObject(value)) {
+                bodyPretty += '\n' + colorize('yellow', key.toUpperCase()) + '\n';
+
+                var sanitized = {};
+
+                each(value, function (innerValue, innerKey) {
+                    if (!isEmpty(innerValue)) {
+                        sanitized[innerKey] = innerValue;
+                    }
+                });
+
+                bodyPretty += prettyjson.render(sanitized, {}) + '\n';
+            } else {
+                bodyPretty += prettyjson.render(value, {}) + '\n';
+            }
+        });
+
+        if (this.mode !== 'short' && (bodyPretty !== data.msg)) {
+            output += format('%s\n', colorize('grey', bodyPretty));
         }
 
         cb(null, output);

--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -8,6 +8,7 @@ module.exports = function createNewInstance(options) {
     options = options || {};
 
     var adapter = new GhostLogger({
+        name: options.name,
         domain: options.domain,
         env: options.env,
         mode: options.mode,
@@ -16,7 +17,8 @@ module.exports = function createNewInstance(options) {
         transports: options.transports,
         rotation: options.rotation,
         path: options.path,
-        loggly: options.loggly
+        loggly: options.loggly,
+        gelf: options.gelf
     });
 
     return adapter;

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -422,7 +422,7 @@ describe('Logging', function () {
 
                 writeStream._write = function (data) {
                     data = data.toString();
-                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[31m\n\u001b[31mHey Jude!\u001b[39m\n\n\u001b[1m\u001b[37mError Code: \u001b[39m\u001b[22m\n    \u001b[90mHEY_JUDE\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n');
+                    data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m message\n\u001b[31m\n\u001b[31mHey Jude!\u001b[39m\n\n\u001b[1m\u001b[37mError Code: \u001b[39m\u001b[22m\n    \u001b[90mHEY_JUDE\u001b[39m\n\n\u001b[90m----------------------------------------\u001b[39m\n\n\u001b[90mstack\u001b[39m\n\u001b[39m\n');
                     done();
                 };
 

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -33,6 +33,44 @@ describe('Logging', function () {
         ghostLogger.info({err: new Error('message'), req: {body: {}, headers: {}}, res: {headers: {}}});
     });
 
+    it('ensure stdout write properties with custom message', function (done) {
+        sandbox.stub(PrettyStream.prototype, 'write', function (data) {
+            should.exist(data);
+            data.name.should.eql('Log');
+            data.msg.should.eql('A handled error! Original message');
+            done();
+        });
+
+        var ghostLogger = new GhostLogger();
+        ghostLogger.warn('A handled error!', new Error('Original message'));
+    });
+
+    it('ensure stdout write properties with object', function (done) {
+        sandbox.stub(PrettyStream.prototype, 'write', function (data) {
+            should.exist(data.err);
+            data.test.should.eql(2);
+            data.name.should.eql('Log');
+            data.msg.should.eql('Got an error from 3rd party service X! Resource could not be found.');
+            done();
+        });
+
+        var ghostLogger = new GhostLogger();
+        ghostLogger.error({err: new errors.NotFoundError(), test: 2}, 'Got an error from 3rd party service X!');
+    });
+
+    it('ensure stdout write properties with util.format', function (done) {
+        sandbox.stub(PrettyStream.prototype, 'write', function (data) {
+            should.exist(data);
+            data.name.should.eql('Log');
+            data.msg.should.eql('Message with format');
+            done();
+        });
+
+        var ghostLogger = new GhostLogger();
+        var thing = 'format';
+        ghostLogger.info('Message with %s', thing);
+    });
+
     it('redact sensitive data with request body', function (done) {
         sandbox.stub(PrettyStream.prototype, 'write', function (data) {
             should.exist(data.req.body.password);


### PR DESCRIPTION
closes #45
Fixes a couple of issues including: `logging.warn('A friendly message.', err);` throwing a TypeError and `logging.warn('A friendly message.', {err: err});` resulting in the error printed as: [object Object].