### PR TITLE
Redact sensitive data rather than remove

### DIFF
--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -230,11 +230,7 @@ class GhostLogger {
     setSerializers() {
         this.serializers = {
             req: (req) => {
-                var reqBody = this.logBody ?
-                    this.removeSensitiveData(req.body) :
-                    undefined
-
-                return {
+                const requestLog = {
                     meta: {
                         requestId: req.requestId,
                         userId: req.userId
@@ -244,9 +240,16 @@ class GhostLogger {
                     originalUrl: req.originalUrl,
                     params: req.params,
                     headers: this.removeSensitiveData(req.headers),
-                    body: reqBody,
                     query: this.removeSensitiveData(req.query)
                 };
+
+                if (this.logBody) {
+                    Object.assign(requestLog, {
+                      body: this.removeSensitiveData(req.body)
+                    });
+                }
+
+                return requestLog;
             },
             res: (res) => {
                 return {

--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -244,9 +244,7 @@ class GhostLogger {
                 };
 
                 if (this.logBody) {
-                    Object.assign(requestLog, {
-                      body: this.removeSensitiveData(req.body)
-                    });
+                    requestLog.body = this.removeSensitiveData(req.body);
                 }
 
                 return requestLog;

--- a/lib/logging/GhostLogger.js
+++ b/lib/logging/GhostLogger.js
@@ -17,6 +17,7 @@ class GhostLogger {
         this.domain = options.domain || 'localhost';
         this.transports = options.transports || ['stdout'];
         this.level = process.env.LEVEL || options.level || 'info';
+        this.logBody = options.logBody || false;
         this.mode = process.env.MODE || options.mode || 'short';
         this.path = options.path || process.cwd();
         this.loggly = options.loggly || {};
@@ -229,6 +230,10 @@ class GhostLogger {
     setSerializers() {
         this.serializers = {
             req: (req) => {
+                var reqBody = this.logBody ?
+                    this.removeSensitiveData(req.body) :
+                    undefined
+
                 return {
                     meta: {
                         requestId: req.requestId,
@@ -239,6 +244,7 @@ class GhostLogger {
                     originalUrl: req.originalUrl,
                     params: req.params,
                     headers: this.removeSensitiveData(req.headers),
+                    body: reqBody,
                     query: this.removeSensitiveData(req.query)
                 };
             },
@@ -277,7 +283,10 @@ class GhostLogger {
                     value = this.removeSensitiveData(value);
                 }
 
-                if (!key.match(/pin|password|authorization|cookie/gi)) {
+                if (key.match(/pin|password|pass|key|authorization|bearer|cookie/gi)) {
+                    newObj[key] = '**REDACTED**'
+                }
+                else {
                     newObj[key] = value;
                 }
             } catch (err) {

--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -12,6 +12,7 @@ module.exports = function createNewInstance(options) {
         env: options.env,
         mode: options.mode,
         level: options.level,
+        logBody: options.logBody,
         transports: options.transports,
         rotation: options.rotation,
         path: options.path,

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -33,18 +33,19 @@ describe('Logging', function () {
         ghostLogger.info({err: new Error('message'), req: {body: {}, headers: {}}, res: {headers: {}}});
     });
 
-    it('remove sensitive data', function (done) {
+    it('redact sensitive data with request body', function (done) {
         sandbox.stub(PrettyStream.prototype, 'write', function (data) {
-            should.not.exist(data.req.body);
-            should.exist(data.req.headers);
-            should.not.exist(data.req.headers.authorization);
-            should.exist(data.req.headers.Connection);
+            should.exist(data.req.body.password);
+            data.req.body.password.should.eql('**REDACTED**');
+            should.exist(data.req.body.data.attributes.pin);
+            data.req.body.data.attributes.pin.should.eql('**REDACTED**');
+            should.exist(data.req.body.data.attributes.test);
             should.exist(data.err);
             should.exist(data.err.errorDetails);
             done();
         });
 
-        var ghostLogger = new GhostLogger();
+        var ghostLogger = new GhostLogger({logBody: true});
 
         ghostLogger.error({
             err: new errors.IncorrectUsageError({message: 'Hallo', errorDetails: []}),


### PR DESCRIPTION
closes #88

Removing sensitive key / value pairs makes troubleshooting difficult, was the header or value ever there at all? Now the value will be replaces with the string `'**REDACTED**'`. This commit also makes logging of a request body configurable rather than removing it altogether. There are systems for which logging the body is useful (backend / service APIs).