### PR TITLE
Improved support for environment variables

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -19,7 +19,10 @@ var setupConfig = function setupConfig() {
     }
 
     config.argv()
-        .env()
+        .env({
+            separator: '__',
+            lowerCase: true
+        })
         .file({
             file: path.join(parentPath, 'config.' + env + '.json')
         });

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -20,8 +20,7 @@ var setupConfig = function setupConfig() {
 
     config.argv()
         .env({
-            separator: '__',
-            lowerCase: true
+            separator: '__'
         })
         .file({
             file: path.join(parentPath, 'config.' + env + '.json')


### PR DESCRIPTION
no-issue

When running applications with `docker-compose` it is nice to pass config as environment variables defined in the `docker-compose.yml`

This change will allow an environment variable like `DATABASE__HOST` (note double underscores)
To be read like `Ignition.config().get('database:host')`